### PR TITLE
Automatically convert underscores to hyphens in `attrs`

### DIFF
--- a/docs/docs/template-tags-filters.md
+++ b/docs/docs/template-tags-filters.md
@@ -38,6 +38,19 @@ Boolean values are treated differently. `True` values become empty attributes, a
 <button>Click me</button>
 ```
 
+Underscores in variable names are automatically converted to hyphens. This is useful for `data-`, `aria-`, and custom HTML attributes.
+
+```twig
+{# logo component #}
+<a {% attrs href aria_label %}><img src="logo.png" /></a>
+
+{# Usage #}
+{% logo href="/" aria_label="Slipper's logo" %}
+
+{# Output #}
+<a href="/" aria-label="Slipper's logo"><img src="logo.png" /></a>
+```
+
 It's possible to specify the source of the attribute value by writing it as a keyword argument. This is useful if the attribute name is different from the variable you want to get it from.
 
 ```twig

--- a/slippers/templatetags/slippers.py
+++ b/slippers/templatetags/slippers.py
@@ -90,6 +90,10 @@ def attr_string(key: str, value: Any):
         return key if value else ""
 
     # Replace `_` with `-`
+    # an underscore is not a valid character in an HTML attribute name
+    # a hyphen is not a valid character in a Django template variable name
+    # So we can use an underscore when we want to use a hyphen in an HTML attribute name
+    # e.g. `aria_role` turns into `aria-role`
     key = key.replace("_", "-")
 
     return f'{key}="{value}"'

--- a/slippers/templatetags/slippers.py
+++ b/slippers/templatetags/slippers.py
@@ -75,7 +75,6 @@ def register_components(
 ) -> None:
     if target_register is None:
         target_register = register
-
     for tag_name, template_path in components.items():
         # Inline component
         target_register.tag(f"{tag_name}", create_component_tag(template_path))
@@ -89,6 +88,9 @@ def register_components(
 def attr_string(key: str, value: Any):
     if isinstance(value, bool):
         return key if value else ""
+
+    # Replace `_` with `-`
+    key = key.replace("_", "-")
 
     return f'{key}="{value}"'
 

--- a/tests/templates/avatar.html
+++ b/tests/templates/avatar.html
@@ -1,1 +1,1 @@
-<div {% attrs aria_label %}>I am avatar for {{ user }}</div>
+<div {% attrs %}>I am avatar for {{ user }}</div>

--- a/tests/templates/avatar.html
+++ b/tests/templates/avatar.html
@@ -1,1 +1,1 @@
-<div>I am avatar for {{ user }}</div>
+<div {% attrs aria_label %}>I am avatar for {{ user }}</div>

--- a/tests/templates/avatar.html
+++ b/tests/templates/avatar.html
@@ -1,1 +1,1 @@
-<div {% attrs %}>I am avatar for {{ user }}</div>
+<div>I am avatar for {{ user }}</div>

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -127,6 +127,23 @@ class AttrsTagTest(TestCase):
 
         self.assertHTMLEqual(expected, Template(template).render(context))
 
+    def test_with_hyphens(self):
+        context = Context(
+            {
+                "aria_label": "Search",
+            }
+        )
+
+        template = """
+            <input {% attrs aria_label %}>
+        """
+
+        expected = """
+            <input aria-label="Search">
+        """
+
+        self.assertHTMLEqual(expected, Template(template).render(context))
+
     def test_boolean_values(self):
         context = Context(
             {


### PR DESCRIPTION
This PR adds the ability to use `data-`, `aria-`, or other HTML attributes that have hyphens on the `{% attrs %}` tag.

For example:

```django
{# logo component #}
<a {% attrs href aria_label %}><img src="logo.png" /></a>

{# Usage #}
{% logo href="/" aria_label="Slipper's logo" %}

{# Output #}
<a href="/" aria-label="Slipper's logo"><img src="logo.png" /></a>
```

This fixes #16 .