### PR TITLE
Update typeguard max dependency.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ include = [
 python = ">=3.7.0"
 Django = ">=3.2"
 PyYAML = ">=5.4.0"
-typeguard = ">=2.13.3"
+typeguard = ">=2.13.3,<3"
 rich = ">=12.6.0"
 typing-extensions = ">=4.4.0"
 


### PR DESCRIPTION
```
File ".venv/lib/python3.11/site-packages/slippers/props.py", line 17, in <module>
    from typeguard import check_type, get_type_name
ImportError: cannot import name 'get_type_name' from 'typeguard' (.venv/lib/python3.11/site-packages/typeguard/__init__.py)
```