### PR TITLE
Ease customization of start & end tag

### DIFF
--- a/slippers/templatetags/slippers.py
+++ b/slippers/templatetags/slippers.py
@@ -16,14 +16,13 @@ register = template.Library()
 
 ##
 # Component tags
-def create_component_tag(template_path):
+def create_component_tag(template_path, closing_tag):
     def do_component(parser, token):
         tag_name, *remaining_bits = token.split_contents()
 
-        # Block components start with `#`
-        # Expect a closing tag
-        if tag_name[0] == "#":
-            nodelist = parser.parse((f"/{tag_name[1:]}",))
+        if closing_tag:
+            # Expect a closing tag
+            nodelist = parser.parse((closing_tag,))
             parser.delete_first_token()
         else:
             nodelist = NodeList()
@@ -154,10 +153,15 @@ def register_components(
         target_register = register
     for tag_name, template_path in components.items():
         # Inline component
-        target_register.tag(f"{tag_name}", create_component_tag(template_path))
+        target_register.tag(
+            f"{tag_name}", create_component_tag(template_path, closing_tag=None)
+        )
 
         # Block component
-        target_register.tag(f"#{tag_name}", create_component_tag(template_path))
+        target_register.tag(
+            f"#{tag_name}",
+            create_component_tag(template_path, closing_tag=f"/{tag_name}"),
+        )
 
 
 ##

--- a/tests/templates/custom_register.html
+++ b/tests/templates/custom_register.html
@@ -1,0 +1,2 @@
+<div>This is a custom tag: {{ some_value }}</div>
+<span>{{ children }}</span>

--- a/tests/templatetags/custom_tag.py
+++ b/tests/templatetags/custom_tag.py
@@ -1,0 +1,9 @@
+from django import template
+
+from slippers.templatetags.slippers import create_component_tag
+
+register = template.Library()
+register.tag(
+    "custom_component",
+    create_component_tag("custom_register.html", closing_tag="endcustom_component"),
+)

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -617,3 +617,20 @@ class FragmentTagTest(TestCase):
         """
 
         self.assertHTMLEqual(expected, Template(template).render(context))
+
+
+class CustomRegisterTest(TestCase):
+    def test_basic(self):
+        template = """
+            {% load custom_tag %}
+            {% custom_component some_value="foobar" %}
+            Hello kids
+            {% endcustom_component %}
+        """
+
+        expected = """
+            <div>This is a custom tag: foobar</div>
+            <span>Hello kids</span>
+        """
+
+        self.assertHTMLEqual(expected, Template(template).render(Context()))


### PR DESCRIPTION
To preserve the sensitivity of some IDEs and play nice with djlint.

Address (partially) #27 .

The change to the current codebase is minimal but allow users to easily customize the opening & closing tags.