### PR TITLE
Add emoji support to documentation site

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,10 @@ markdown_extensions:
   - pymdownx.superfences
   - pymdownx.inlinehilite
   - pymdownx.snippets
+  - attr_list
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
 
 extra_css:
   - extra.css


### PR DESCRIPTION
Noticed that there is at least one emoji being referenced (https://mitchel.me/slippers/getting-started/) which is not being rendered.

See: https://squidfunk.github.io/mkdocs-material/reference/icons-emojis/#configuration